### PR TITLE
add utils to get frame (start, end) timestamp

### DIFF
--- a/include/decord/runtime/ndarray.h
+++ b/include/decord/runtime/ndarray.h
@@ -378,7 +378,7 @@ inline void NDArray::CopyFrom(std::vector<T>& other, std::vector<int64_t>& shape
   for (int64_t s : shape) {
     size *= s;
   }
-  CHECK(other.size() == size);
+  CHECK(other.size() == size) << "other: " << other.size() << " this: " << size;
   DLTensor dlt = CreateDLTensorView(other, shape); 
   CopyFromTo(&dlt, &(data_->dl_tensor));
 }

--- a/include/decord/video_interface.h
+++ b/include/decord/video_interface.h
@@ -44,6 +44,8 @@ class VideoReaderInterface {
     virtual runtime::NDArray NextFrame() = 0;
     /*! \brief retrieve keyframe indices */
     virtual runtime::NDArray GetKeyIndices() = 0;
+    /*! \brief retrieve playback seconds by frame indices */
+    virtual runtime::NDArray GetFramePTS() const = 0;
     /*! \brief read bulk frames, defined by indices */
     virtual runtime::NDArray GetBatch(std::vector<int64_t> indices, runtime::NDArray buf) = 0;
     /*! \brief skip certain frames without decoding */

--- a/src/video/threaded_decoder_interface.h
+++ b/src/video/threaded_decoder_interface.h
@@ -18,11 +18,8 @@ class ThreadedDecoderInterface {
         virtual void Start() = 0;
         virtual void Stop() = 0;
         virtual void Clear() = 0;
-        // virtual void Push(ffmpeg::AVPacketPtr pkt) = 0;
         virtual void Push(ffmpeg::AVPacketPtr pkt, runtime::NDArray buf) = 0;
-        // virtual void Skip(ffmpeg::AVPacketPtr pkt) = 0;
         virtual bool Pop(runtime::NDArray *frame) = 0;
-        // virtual bool Pop(ffmpeg::AVFramePtr *frame) = 0;
         virtual void SuggestDiscardPTS(std::vector<int64_t> dts) = 0;
         virtual ~ThreadedDecoderInterface() = default;
 };  // class ThreadedDecoderInterface

--- a/src/video/video_interface.cc
+++ b/src/video/video_interface.cc
@@ -66,6 +66,13 @@ DECORD_REGISTER_GLOBAL("video_reader._CAPI_VideoReaderGetKeyIndices")
     *rv = ret;
   });
 
+DECORD_REGISTER_GLOBAL("video_reader._CAPI_VideoReaderGetFramePTS")
+.set_body([] (DECORDArgs args, DECORDRetValue* rv) {
+    VideoReaderInterfaceHandle handle = args[0];
+    NDArray ret = static_cast<VideoReaderInterface*>(handle)->GetFramePTS();
+    *rv = ret;
+  });
+
 DECORD_REGISTER_GLOBAL("video_reader._CAPI_VideoReaderGetBatch")
 .set_body([] (DECORDArgs args, DECORDRetValue* rv) {
     VideoReaderInterfaceHandle handle = args[0];

--- a/src/video/video_reader.h
+++ b/src/video/video_reader.h
@@ -19,6 +19,16 @@
 
 
 namespace decord {
+using timestamp_t = float;
+struct AVFrameTime {
+    int64_t pts;          // presentation timestamp, unit is stream time_base
+    int64_t dts;          // decoding timestamp, unit is stream time_base
+    timestamp_t start;    // real world start timestamp, unit is second
+    timestamp_t stop;     // real world stop timestamp, unit is second
+
+    AVFrameTime(int64_t pts=AV_NOPTS_VALUE, int64_t dts=AV_NOPTS_VALUE, timestamp_t start=0, timestamp_t stop=0)
+     : pts(pts), dts(dts), start(start), stop(stop) {}
+};  // struct AVFrameTime
 
 class VideoReader : public VideoReaderInterface {
     using ThreadedDecoderPtr = std::unique_ptr<ThreadedDecoderInterface>;
@@ -36,7 +46,8 @@ class VideoReader : public VideoReaderInterface {
         void SkipFrames(int64_t num = 1);
         bool Seek(int64_t pos);
         bool SeekAccurate(int64_t pos);
-        runtime::NDArray GetKeyIndices();
+        NDArray GetKeyIndices();
+        NDArray GetFramePTS() const;
         double GetAverageFPS() const;
     protected:
         friend class VideoLoader;
@@ -51,6 +62,8 @@ class VideoReader : public VideoReaderInterface {
 
         DLContext ctx_;
         std::vector<int64_t> key_indices_;
+        /*! \brief a lookup table for per frame pts/dts */
+        std::vector<AVFrameTime> frame_ts_;
         /*! \brief Video Streams Codecs in original videos */
         std::vector<AVCodec*> codecs_;
         /*! \brief Currently active video stream index */


### PR DESCRIPTION
See issue https://github.com/dmlc/decord/issues/26
However, for now it does not take records of frames that are broken(decoding failure will raise error)

Usage is pretty simple:

```python
vr = VideoReader('xxx.mp4')
vr.get_frame_timestamp(0)
```
The output is a numpy array with format `[(start_second, stop_second)]`
```
[0., 0.033]
```

To get the timestamps information of all frames in the video:
```python
vr.get_frame_timestamp(range(len(vr)))
```