### PR TITLE
Fix 2 issues with CUDA code and apply resize after rotation

### DIFF
--- a/src/video/nvcodec/cuda_threaded_decoder.cc
+++ b/src/video/nvcodec/cuda_threaded_decoder.cc
@@ -96,7 +96,7 @@ void CUThreadedDecoder::InitBitStreamFilter(AVCodecParameters *codecpar, AVInput
     bsf_ctx_.reset(bsf_ctx);
 }
 
-void CUThreadedDecoder::SetCodecContext(AVCodecContext *dec_ctx, int width, int height) {
+void CUThreadedDecoder::SetCodecContext(AVCodecContext *dec_ctx, int width, int height, int rotation) {
     CHECK(dec_ctx);
     width_ = width;
     height_ = height;

--- a/src/video/nvcodec/cuda_threaded_decoder.h
+++ b/src/video/nvcodec/cuda_threaded_decoder.h
@@ -47,7 +47,7 @@ class CUThreadedDecoder final : public ThreadedDecoderInterface {
 
     public:
         CUThreadedDecoder(int device_id, AVCodecParameters *codecpar, AVInputFormat *iformat);
-        void SetCodecContext(AVCodecContext *dec_ctx, int width = -1, int height = -1);
+        void SetCodecContext(AVCodecContext *dec_ctx, int width = -1, int height = -1, int rotation = 0);
         bool Initialized() const;
         void Start();
         void Stop();


### PR DESCRIPTION
Doing some experiments with GPU I realized that, with the latest changes, there were a couple of issues..
1. CUDA version wouldn't build anymore (changed interface), fixed
2. videos with rotation metadata would be rubbish with CUDA version, due to the swap of width and height that affected also the CUDA part of the code (but without actually rotating..)

As additional small change, now width and height passed to the VideoReader refer to the _output_ width and height of the output images, regardless of whether a rotation was applied or not, that is transparent to the user.