### PR TITLE
Make `filter_graph_->nb_threads` be 1, and make number of decoding threads customizable  

### DIFF
--- a/python/decord/video_reader.py
+++ b/python/decord/video_reader.py
@@ -28,13 +28,15 @@ class VideoReader(object):
         Desired output width of the video, unchanged if `-1` is specified.
     height : int, default is -1
         Desired output height of the video, unchanged if `-1` is specified.
+    num_threads : int, default is 0
+        Number of decoding thread, auto if `0` is specified.
 
     """
-    def __init__(self, uri, ctx=cpu(0), width=-1, height=-1):
+    def __init__(self, uri, ctx=cpu(0), width=-1, height=-1, num_threads=0):
         assert isinstance(ctx, DECORDContext)
         self._handle = None
         self._handle = _CAPI_VideoReaderGetVideoReader(
-            uri, ctx.device_type, ctx.device_id, width, height)
+            uri, ctx.device_type, ctx.device_id, width, height, num_threads)
         if self._handle is None:
             raise RuntimeError("Error reading " + uri + "...")
         self._num_frame = _CAPI_VideoReaderGetFrameCount(self._handle)

--- a/src/video/ffmpeg/filter_graph.cc
+++ b/src/video/ffmpeg/filter_graph.cc
@@ -42,7 +42,7 @@ void FFMPEGFilterGraph::Init(std::string filters_descr, AVCodecContext *dec_ctx)
 	filter_graph_.reset(avfilter_graph_alloc());
 	/* automatic threading */
 	//LOG(INFO) << "Original GraphFilter nb_threads: " << filter_graph_->nb_threads;
-	filter_graph_->nb_threads = 0;
+	filter_graph_->nb_threads = 1;
     /* buffer video source: the decoded frames from the decoder will be inserted here. */
 	std::snprintf(args, sizeof(args),
             "video_size=%dx%d:pix_fmt=%d:time_base=%d/%d:pixel_aspect=%d/%d",

--- a/src/video/ffmpeg/filter_graph.cc
+++ b/src/video/ffmpeg/filter_graph.cc
@@ -40,7 +40,7 @@ void FFMPEGFilterGraph::Init(std::string filters_descr, AVCodecContext *dec_ctx)
 	// AVBufferSinkParams *buffersink_params;
 
 	filter_graph_.reset(avfilter_graph_alloc());
-	/* automatic threading */
+	/* set threads to 1, details see https://github.com/dmlc/decord/pull/63 */
 	//LOG(INFO) << "Original GraphFilter nb_threads: " << filter_graph_->nb_threads;
 	filter_graph_->nb_threads = 1;
     /* buffer video source: the decoded frames from the decoder will be inserted here. */

--- a/src/video/video_interface.cc
+++ b/src/video/video_interface.cc
@@ -31,10 +31,11 @@ DECORD_REGISTER_GLOBAL("video_reader._CAPI_VideoReaderGetVideoReader")
     int device_id = args[2];
     int width = args[3];
     int height = args[4];
+    int num_thread = args[5];
     DLContext ctx;
     ctx.device_type = static_cast<DLDeviceType>(device_type);
     ctx.device_id = device_id;
-    VideoReaderInterfaceHandle handle = static_cast<VideoReaderInterfaceHandle>(new VideoReader(fn, ctx, width, height));
+    VideoReaderInterfaceHandle handle = static_cast<VideoReaderInterfaceHandle>(new VideoReader(fn, ctx, width, height, num_thread));
     *rv = handle;
   });
 

--- a/src/video/video_reader.cc
+++ b/src/video/video_reader.cc
@@ -22,9 +22,9 @@ using FFMPEGThreadedDecoder = ffmpeg::FFMPEGThreadedDecoder;
 using AVFramePool = ffmpeg::AVFramePool;
 using AVPacketPool = ffmpeg::AVPacketPool;
 
-VideoReader::VideoReader(std::string fn, DLContext ctx, int width, int height)
+VideoReader::VideoReader(std::string fn, DLContext ctx, int width, int height, int nb_thread)
      : ctx_(ctx), key_indices_(), frame_ts_(), codecs_(), actv_stm_idx_(-1), decoder_(), curr_frame_(0),
-     width_(width), height_(height), eof_(false) {
+     nb_thread_decoding_(nb_thread), width_(width), height_(height), eof_(false) {
     // av_register_all deprecated in latest versions
     #if ( LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58,9,100) )
     av_register_all();
@@ -107,7 +107,8 @@ void VideoReader::SetVideoStream(int stream_nb) {
     }
 
     auto dec_ctx = avcodec_alloc_context3(dec);
-    dec_ctx->thread_count = 0;
+    // LOG(INFO) << "nb_thread_decoding_: " << nb_thread_decoding_;
+    dec_ctx->thread_count = nb_thread_decoding_;
     // LOG(INFO) << "Original decoder multithreading: " << dec_ctx->thread_count;
     // CHECK_GE(avcodec_copy_context(dec_ctx, fmt_ctx_->streams[stream_nb]->codec), 0) << "Error: copy context";
     // CHECK_GE(avcodec_parameters_to_context(dec_ctx, fmt_ctx_->streams[st_nb]->codecpar), 0) << "Error: copy parameters to codec context.";

--- a/src/video/video_reader.h
+++ b/src/video/video_reader.h
@@ -34,7 +34,7 @@ class VideoReader : public VideoReaderInterface {
     using ThreadedDecoderPtr = std::unique_ptr<ThreadedDecoderInterface>;
     using NDArray = runtime::NDArray;
     public:
-        VideoReader(std::string fn, DLContext ctx, int width=-1, int height=-1);
+        VideoReader(std::string fn, DLContext ctx, int width=-1, int height=-1, int nb_thread=0);
         /*! \brief Destructor, note that FFMPEG resources has to be managed manually to avoid resource leak */
         ~VideoReader();
         void SetVideoStream(int stream_nb = -1);
@@ -73,6 +73,7 @@ class VideoReader : public VideoReaderInterface {
         ffmpeg::AVFormatContextPtr fmt_ctx_;
         ThreadedDecoderPtr decoder_;
         int64_t curr_frame_;  // current frame location
+        int64_t nb_thread_decoding_;  // number of threads for decoding
         int width_;   // output video width
         int height_;  // output video height
         bool eof_;  // end of file indicator


### PR DESCRIPTION
The makes the time spent on this function deterministic, and hence faster.
Testing on 32 videos shows 1.3x speedup:
![image](https://user-images.githubusercontent.com/9464825/81149150-3e45cf80-8fb0-11ea-8b17-8df900cb3d37.png)

Testing code:
![image](https://user-images.githubusercontent.com/9464825/81149600-17d46400-8fb1-11ea-9f52-fee0a700c32e.png)
