### PR TITLE
Add timestamps for key indices

### DIFF
--- a/src/video/video_reader.cc
+++ b/src/video/video_reader.cc
@@ -25,7 +25,7 @@ static const int AVIO_BUFFER_SIZE = 40960;
 
 
 VideoReader::VideoReader(std::string fn, DLContext ctx, int width, int height, int nb_thread, int io_type)
-     : ctx_(ctx), key_indices_(), key_indices_ts_(), frame_ts_(), codecs_(), actv_stm_idx_(-1), fmt_ctx_(nullptr), decoder_(nullptr), curr_frame_(0),
+     : ctx_(ctx), key_indices_(), frame_ts_(), codecs_(), actv_stm_idx_(-1), fmt_ctx_(nullptr), decoder_(nullptr), curr_frame_(0),
      nb_thread_decoding_(nb_thread), width_(width), height_(height), eof_(false), io_ctx_() {
     // av_register_all deprecated in latest versions
     #if ( LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58,9,100) )
@@ -249,12 +249,7 @@ int64_t VideoReader::GetCurrentPosition() const {
 }
 
 int64_t VideoReader::FrameToPTS(int64_t pos) {
-    std::map<int64_t, int64_t>::iterator iter = key_indices_ts_.find(pos);
-    int64_t ts;
-    if(iter != key_indices_ts_.end())
-        ts = iter->second;
-    else
-        ts = pos * fmt_ctx_->streams[actv_stm_idx_]->duration / GetFrameCount();
+    int64_t ts = frame_ts_[pos].pts;
     return ts;
 }
 
@@ -416,7 +411,6 @@ void VideoReader::IndexKeyframes() {
             frame_ts_.emplace_back(AVFrameTime(packet->pts, packet->dts, start_pts, stop_pts));
             if (packet->flags & AV_PKT_FLAG_KEY) {
                 key_indices_.emplace_back(cnt);
-                key_indices_ts_.insert(std::pair<int64_t, int64_t>(cnt, packet->pts));
             }
             ++cnt;
         }

--- a/src/video/video_reader.h
+++ b/src/video/video_reader.h
@@ -63,6 +63,7 @@ class VideoReader : public VideoReaderInterface {
         
         DLContext ctx_;
         std::vector<int64_t> key_indices_;
+        std::map<int64_t,int64_t > key_indices_ts_;
         /*! \brief a lookup table for per frame pts/dts */
         std::vector<AVFrameTime> frame_ts_;
         /*! \brief Video Streams Codecs in original videos */

--- a/src/video/video_reader.h
+++ b/src/video/video_reader.h
@@ -63,7 +63,6 @@ class VideoReader : public VideoReaderInterface {
         
         DLContext ctx_;
         std::vector<int64_t> key_indices_;
-        std::map<int64_t,int64_t > key_indices_ts_;
         /*! \brief a lookup table for per frame pts/dts */
         std::vector<AVFrameTime> frame_ts_;
         /*! \brief Video Streams Codecs in original videos */


### PR DESCRIPTION
This PR improves the function `FrameToPTS` by using the timestamp stored for keyframes rather than calculating the timestamp using duration and frame count. This can improve the accuracy of timestamps because the timestamps are not distributed uniformly in some videos. 

To be more specific, for the previous calculation, it assumes that the timestamp for frame `i` is a multiple of `i`. But this is not always correct. The incorrect calculation will result in an incorrect keyframe found and the decoded frame will be incorrect as well. This could happen when not sampling with consecutive order. (Similar issue mentioned in https://github.com/dmlc/decord/issues/54)

Therefore, we save the timestamp for every keyframe during initialization and use this timestamp directly. 

In my test case of 500 videos, I randomly sample 3 frames from each of these videos and compare the decoded frames with PyAV which are ensured to be correct. The results show that before modifying, there are 226 videos that have incorrectly-decoded frames; after modifying, there are 150 videos that have incorrectly-decoded frames. They have an overlap of 143 videos which both occur before and after modifying. 

Here is my test code for one video.
``` Python 
def analysis(filename):
    container = decord.VideoReader(filename, num_threads=0)
    file_obj = io.BytesIO(file_client.get(filename))
    container_av = av.open(file_obj)
    imgs = list()
    for frame in container_av.decode(video=0):
        imgs.append(frame.to_rgb().to_ndarray())
    frame_list = np.random.randint(1, len(imgs), size=3)
    incorrect = False
    for i, frame_idx in enumerate(frame_list):
        frame_decord = container[frame_idx].asnumpy()
        frame_pyav = imgs[frame_idx]  
        if np.sum(abs(frame_pyav - frame_decord)) != 0:
            print(filename, frame_list, frame_idx)
            print("different result: ", np.sum(abs(frame_py - frame_decord)))
            incorrect = True
    return incorrect 
```

Signed-off-by: lixuanyi <lixuanyi@sensetime.com>