### PR TITLE
Fix a case when seek keyframe goes to eof

### DIFF
--- a/include/decord/runtime/ndarray.h
+++ b/include/decord/runtime/ndarray.h
@@ -35,7 +35,7 @@ namespace runtime {
 class NDArray {
  public:
   // pts of the frame
-  int pts=0;
+  int pts=-1;
   // internal container type
   struct Container;
   /*! \brief default constructor */

--- a/src/video/video_reader.cc
+++ b/src/video/video_reader.cc
@@ -549,6 +549,16 @@ bool VideoReader::CheckKeyFrame()
         ret = decoder_->Pop(&frame);
     }
 
+    if (eof_ && frame.pts == -1){
+        // wrongly jumpped to the end of file
+        curr_frame_ = GetFrameCount();
+        return false;
+    }
+
+    if(frame.pts == -1){
+        LOG(FATAL) << "Error seeking keyframe: " << curr_frame_ << " with total frames: " << GetFrameCount();
+    }
+
     // find the real current frame after decoding
     auto iter = pts_frame_map_.find(frame.pts);
     if (iter != pts_frame_map_.end())


### PR DESCRIPTION
In very rare cases, seeking keyframe might go to the end of file because currently we used the flag 0 sometimes.
