### PR TITLE
[Video Reader] add caching and retry limit for bad video tolerance

### DIFF
--- a/python/decord/__init__.py
+++ b/python/decord/__init__.py
@@ -3,7 +3,7 @@ from . import function
 
 from ._ffi.runtime_ctypes import TypeCode
 from ._ffi.function import register_func, get_global_func, list_global_func_names, extract_ext_funcs
-from ._ffi.base import DECORDError, __version__
+from ._ffi.base import DECORDError, DECORDLimitReachedError, __version__
 
 from .base import ALL
 

--- a/src/runtime/str_util.cc
+++ b/src/runtime/str_util.cc
@@ -4,6 +4,7 @@
  * \brief Minimum string manipulation util for runtime.
  */
 
+#include "str_util.h"
 #include "file_util.h"
 
 namespace decord {
@@ -19,6 +20,30 @@ std::vector<std::string> SplitString(std::string const &in, char sep) {
         b = e;
     }
     return result;
+}
+
+std::string GetEnvironmentVariableOrDefault(const std::string& variable_name,
+                                            const std::string& default_value)
+{
+    const char* value = getenv(variable_name.c_str());
+    return value ? value : default_value;
+}
+
+int ParseIntOrFloat(const std::string& str, int64_t& ivalue, double& fvalue) {
+    char* p = nullptr;
+    auto i = std::strtol(str.data(), &p, 10);
+    if (p == str.data() + str.size()) {
+        ivalue = int64_t(i);
+        return 0;
+    }
+
+    auto f = std::strtod(str.data(), &p);
+    if (p == str.data() + str.size()) {
+        fvalue = f;
+        return 1;
+    }
+
+    return -1;
 }
 
 }  // namespace runtime

--- a/src/runtime/str_util.h
+++ b/src/runtime/str_util.h
@@ -14,6 +14,10 @@ namespace runtime {
 
 std::vector<std::string> SplitString(std::string const &in, char sep);
 
-}  // namespace decord
+std::string GetEnvironmentVariableOrDefault(const std::string& variable_name,
+                                            const std::string& default_value);
+
+int ParseIntOrFloat(const std::string& str, int64_t& ivalue, double& fvalue);
+}  // namespace runtime
 }  // namespace decord
 #endif  // DECORD_RUNTIME_STR_UTIL_H_

--- a/src/video/video_interface.cc
+++ b/src/video/video_interface.cc
@@ -17,9 +17,10 @@
 
 namespace decord {
 
-VideoReaderPtr GetVideoReader(std::string fn, DLContext ctx, int width, int height, int nb_thread, int io_type) {
+VideoReaderPtr GetVideoReader(std::string fn, DLContext ctx, int width, int height, int nb_thread,
+                              int io_type, std::string fault_tol) {
     std::shared_ptr<VideoReaderInterface> ptr;
-    ptr = std::make_shared<VideoReader>(fn, ctx, width, height, nb_thread, io_type);
+    ptr = std::make_shared<VideoReader>(fn, ctx, width, height, nb_thread, io_type, fault_tol);
     return ptr;
 }
 
@@ -33,10 +34,11 @@ DECORD_REGISTER_GLOBAL("video_reader._CAPI_VideoReaderGetVideoReader")
     int height = args[4];
     int num_thread = args[5];
     int io_type = args[6];
+    std::string fault_tol = args[7];
     DLContext ctx;
     ctx.device_type = static_cast<DLDeviceType>(device_type);
     ctx.device_id = device_id;
-    auto reader = new VideoReader(fn, ctx, width, height, num_thread, io_type);
+    auto reader = new VideoReader(fn, ctx, width, height, num_thread, io_type, fault_tol);
     if (reader->GetFrameCount() <= 0) {
       *rv = nullptr;
       return;

--- a/src/video/video_reader.cc
+++ b/src/video/video_reader.cc
@@ -266,6 +266,9 @@ int64_t VideoReader::GetFrameCount() const {
         // many formats do not provide accurate frame count, use duration and FPS to approximate
         cnt = static_cast<double>(stm->avg_frame_rate.num) / stm->avg_frame_rate.den * fmt_ctx_->duration / AV_TIME_BASE;
     }
+    if (cnt < 1) {
+        LOG(FATAL) << "[" << filename_ << "] Failed to measure duration/frame-count due to broken metadata."
+    }
     return cnt;
 }
 

--- a/src/video/video_reader.cc
+++ b/src/video/video_reader.cc
@@ -267,7 +267,7 @@ int64_t VideoReader::GetFrameCount() const {
         cnt = static_cast<double>(stm->avg_frame_rate.num) / stm->avg_frame_rate.den * fmt_ctx_->duration / AV_TIME_BASE;
     }
     if (cnt < 1) {
-        LOG(FATAL) << "[" << filename_ << "] Failed to measure duration/frame-count due to broken metadata."
+        LOG(FATAL) << "[" << filename_ << "] Failed to measure duration/frame-count due to broken metadata.";
     }
     return cnt;
 }
@@ -717,13 +717,14 @@ bool VideoReader::FetchCachedFrame(NDArray &frame, int64_t pos) {
   }
   frame.CopyFrom(cached_frame_);
   failed_idx_.insert(pos);
+  int64_t failed_count = failed_idx_.size();
   if (fault_tol_thresh_ >= 0) {
-      if (failed_idx_.size() > fault_tol_thresh_) {
+      if (failed_count > fault_tol_thresh_) {
           LOG(FATAL) << "[" << filename_ << "]You have received more than " << fault_tol_thresh_
             << " duplicate frames that are corrupted and recovered from nearest frames.";
       }
   }
-  if (failed_idx_.size() > DUPLICATE_WARNING_THRESHOLD * GetFrameCount()) {
+  if (failed_count > DUPLICATE_WARNING_THRESHOLD * GetFrameCount()) {
       if (!fault_warn_emit_) {
           LOG(WARNING) << "[" << filename_ << "]You have received more than " << failed_idx_.size()
             << " frames corrupted and recovered from nearest frames."

--- a/src/video/video_reader.cc
+++ b/src/video/video_reader.cc
@@ -22,11 +22,13 @@ using FFMPEGThreadedDecoder = ffmpeg::FFMPEGThreadedDecoder;
 using AVFramePool = ffmpeg::AVFramePool;
 using AVPacketPool = ffmpeg::AVPacketPool;
 static const int AVIO_BUFFER_SIZE = 40960;
+static const int REWIND_RETRY_MAX = 16;
+static const int EOF_RETRY_MAX = 1024;
 
 
 VideoReader::VideoReader(std::string fn, DLContext ctx, int width, int height, int nb_thread, int io_type)
      : ctx_(ctx), key_indices_(), pts_frame_map_(), tmp_key_frame_(), overrun_(false), frame_ts_(), codecs_(), actv_stm_idx_(-1), fmt_ctx_(nullptr), decoder_(nullptr), curr_frame_(0),
-     nb_thread_decoding_(nb_thread), width_(width), height_(height), eof_(false), io_ctx_() {
+     nb_thread_decoding_(nb_thread), width_(width), height_(height), eof_(false), io_ctx_(), use_cached_frame_(true) {
     // av_register_all deprecated in latest versions
     #if ( LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58,9,100) )
     av_register_all();
@@ -50,6 +52,7 @@ VideoReader::VideoReader(std::string fn, DLContext ctx, int width, int height, i
         //     return;
         // #endif
     } else if (io_type == kRawBytes) {
+        filename_ = "BytesIO";
         io_ctx_.reset(new ffmpeg::AVIOBytesContext(fn, AVIO_BUFFER_SIZE));
         fmt_ctx = avformat_alloc_context();
         CHECK(fmt_ctx != nullptr) << "Unable to alloc avformat context";
@@ -60,6 +63,7 @@ VideoReader::VideoReader(std::string fn, DLContext ctx, int width, int height, i
         }
         open_ret = avformat_open_input(&fmt_ctx, NULL, NULL, NULL);
     } else if (io_type == kNormal) {
+        filename_ = fn;
         open_ret = avformat_open_input(&fmt_ctx, fn.c_str(), NULL, NULL);
     } else {
         LOG(WARNING) << "Invalid io type: " << io_type;
@@ -266,6 +270,7 @@ bool VideoReader::Seek(int64_t pos) {
     if (!fmt_ctx_) return false;
     if (curr_frame_ == pos) return true;
     decoder_->Clear();
+    cached_frame_ = NDArray();
     eof_ = false;
 
     int64_t ts = FrameToPTS(pos);
@@ -355,7 +360,6 @@ void VideoReader::PushNext() {
             return;
         }
         if (packet->stream_index == actv_stm_idx_) {
-
             if (ctx_.device_type != kDLGPU) {
                     // no preallocated memory and memory pool, use FFMPEG AVFrame pool
                     decoder_->Push(packet, NDArray());
@@ -380,8 +384,8 @@ NDArray VideoReader::NextFrameImpl() {
     decoder_->Start();
     bool ret = false;
     int rewind_offset = 0;
+    int retry = 0;
     while (!ret) {
-        // std::cout << "!!" << std::endl;
         PushNext();
         if (curr_frame_ >= GetFrameCount()) {
             return NDArray::Empty({}, kUInt8, ctx_);
@@ -389,14 +393,34 @@ NDArray VideoReader::NextFrameImpl() {
         ret = decoder_->Pop(&frame);
         if (frame.Size() <= 1) {
             if (frame.defined() && frame.data_->dl_tensor.dtype == kInt64) {
+              // draining finished
+              if (FetchCachedFrame(frame)) {
+                ret = true;
+              } else {
+                if (rewind_offset > REWIND_RETRY_MAX) {
+                  LOG(FATAL) << "[" << filename_ << "]Unable to handle EOF, exit...";
+                }
                 SeekAccurate(curr_frame_ - rewind_offset);
                 ++rewind_offset;
+                ret = false;
+              }
+            } else {
+              // skipped frames or waiting for more packets
+              if (eof_ && retry > EOF_RETRY_MAX) {
+                if (FetchCachedFrame(frame)) {
+                  break;
+                } else {
+                  LOG(FATAL) << "[" << filename_ << "]Unable to handle EOF, exit...";
+                }
+              }
+              retry++;
+              ret = false;
             }
-            ret = false;
         }
     }
     if (frame.defined()) {
         ++curr_frame_;
+        CacheFrame(frame);
     }
     return frame;
 }
@@ -648,6 +672,26 @@ NDArray VideoReader::GetBatch(std::vector<int64_t> indices, NDArray buf) {
         }
     }
     return buf;
+}
+
+void VideoReader::CacheFrame(NDArray frame) {
+  if (!use_cached_frame_) return;
+  if (!cached_frame_.defined()) {
+    cached_frame_ = NDArray::Empty({height_, width_, 3}, kUInt8, ctx_);
+  }
+  if (!frame.defined()) return;
+  if (cached_frame_.Size() != frame.Size()) return;
+  cached_frame_.CopyFrom(frame);
+}
+
+bool VideoReader::FetchCachedFrame(NDArray &frame) {
+  if (!use_cached_frame_) return false;
+  if (cached_frame_.Size() <= 1) return false;
+  if (!frame.defined() || frame.Size() != cached_frame_.Size()) {
+    frame = NDArray::Empty({height_, width_, 3}, kUInt8, ctx_);
+  }
+  frame.CopyFrom(cached_frame_);
+  return true;
 }
 
 }  // namespace decord

--- a/src/video/video_reader.h
+++ b/src/video/video_reader.h
@@ -62,6 +62,8 @@ class VideoReader : public VideoReaderInterface {
         NDArray NextFrameImpl();
         int64_t FrameToPTS(int64_t pos);
         std::vector<int64_t> FramesToPTS(const std::vector<int64_t>& positions);
+        void CacheFrame(NDArray frame);
+        bool FetchCachedFrame(NDArray &frame);
 
         DLContext ctx_;
         std::vector<int64_t> key_indices_;
@@ -84,7 +86,9 @@ class VideoReader : public VideoReaderInterface {
         bool eof_;  // end of file indicator
         NDArrayPool ndarray_pool_;
         std::unique_ptr<ffmpeg::AVIOBytesContext> io_ctx_;  // avio context for raw memory access
-
+        std::string filename_;  // file name if from file directly, can be empty if from bytes
+        NDArray cached_frame_;  // last valid frame, for error tolerance
+        bool use_cached_frame_;  // switch to enable cache
 };  // class VideoReader
 }  // namespace decord
 #endif  // DECORD_VIDEO_VIDEO_READER_H_

--- a/src/video/video_reader.h
+++ b/src/video/video_reader.h
@@ -34,7 +34,8 @@ class VideoReader : public VideoReaderInterface {
     using ThreadedDecoderPtr = std::unique_ptr<ThreadedDecoderInterface>;
     using NDArray = runtime::NDArray;
     public:
-        VideoReader(std::string fn, DLContext ctx, int width=-1, int height=-1, int nb_thread=0, int io_type=kNormal);
+        VideoReader(std::string fn, DLContext ctx, int width=-1, int height=-1,
+                    int nb_thread=0, int io_type=kNormal, std::string fault_tol="-1");
         /*! \brief Destructor, note that FFMPEG resources has to be managed manually to avoid resource leak */
         ~VideoReader();
         void SetVideoStream(int stream_nb = -1);
@@ -63,7 +64,7 @@ class VideoReader : public VideoReaderInterface {
         int64_t FrameToPTS(int64_t pos);
         std::vector<int64_t> FramesToPTS(const std::vector<int64_t>& positions);
         void CacheFrame(NDArray frame);
-        bool FetchCachedFrame(NDArray &frame);
+        bool FetchCachedFrame(NDArray &frame, int64_t pos);
 
         DLContext ctx_;
         std::vector<int64_t> key_indices_;
@@ -88,7 +89,10 @@ class VideoReader : public VideoReaderInterface {
         std::unique_ptr<ffmpeg::AVIOBytesContext> io_ctx_;  // avio context for raw memory access
         std::string filename_;  // file name if from file directly, can be empty if from bytes
         NDArray cached_frame_;  // last valid frame, for error tolerance
-        bool use_cached_frame_;  // switch to enable cache
+        bool use_cached_frame_;  // switch to enable frame recovery if failed to decode
+        std::unordered_set<int64_t> failed_idx_;  // idx of failed frames(recovered from other frames)
+        int64_t fault_tol_thresh_;  // fault tolerance threshold, raise if recovered frames retrieved exceeds thresh
+        bool fault_warn_emit_;  // whether a fault warning has been emitted
 };  // class VideoReader
 }  // namespace decord
 #endif  // DECORD_VIDEO_VIDEO_READER_H_


### PR DESCRIPTION
Add cached frame in case some video is corrupted and in the previous version it's silently handled by rewinding to nearest "good" frame, this will increase the chance of infinite rewinding if the video is completely corrupted.

So if a corrupted video is read by VideoReader with some `bad` frames(e.g., 200-300 out of 300 frames), retrieving `vr[200]` to `vr[299] will return vr[199] instead.

If you don't care about duplicate frames in this case, no worries. 
If you want to prevent this from happening frequently(not ideal for training), then set the hard limit and catch the error on the fly to detect bad videos:

```python
from decord import DECORDLimitReachedError
# accept at most 10 corrupted and recovered frames:
for video in videos:
    vr = VideoReader(video, fault_tol=10)
    # or percentage, e.g. 10% bad frames allowed
    # vr = VideoReader(video, fault_tol=0.1)
    try:
         # do what ever, read batch or loop
    except DECORDLimitReachedError:
        # handle bad video
    except DECORDError:
        # handle other types of error raised from decord

```
