### PR TITLE
fix tensorflow dlpack context init

### DIFF
--- a/python/decord/bridge/tf.py
+++ b/python/decord/bridge/tf.py
@@ -18,7 +18,11 @@ def try_import_tfdl():
 def to_tensorflow(decord_arr):
     """from decord to tensorflow, no copy"""
     tfdl = try_import_tfdl()
-    return tfdl.from_dlpack(decord_arr.to_dlpack())
+    from tensorflow.python import pywrap_tfe
+    from tensorflow.python.eager import context
+    ctx = context.context()
+    ctx.ensure_initialized()
+    return pywrap_tfe.TFE_FromDlpackCapsule(decord_arr.to_dlpack(), ctx._handle)
 
 def from_tensorflow(tf_tensor):
     """from tensorflow to decord, no copy"""

--- a/python/decord/video_reader.py
+++ b/python/decord/video_reader.py
@@ -62,8 +62,11 @@ class VideoReader(object):
         self._avg_fps = None
 
     def __del__(self):
-        if self._handle:
-            _CAPI_VideoReaderFree(self._handle)
+        try:
+            if self._handle is not None:
+                _CAPI_VideoReaderFree(self._handle)
+        except TypeError:
+            pass
 
     def __len__(self):
         """Get length of the video. Note that sometimes FFMPEG reports inaccurate number of frames,


### PR DESCRIPTION
Fix #132, #139.
Fix a bug in tensorflow dlpack support, use pre-inited context instead