### PR TITLE
Bug fix for invalid conversion from AVCodec** to const AVCodec**

### DIFF
--- a/src/video/video_reader.cc
+++ b/src/video/video_reader.cc
@@ -145,7 +145,7 @@ VideoReader::~VideoReader(){
 
 void VideoReader::SetVideoStream(int stream_nb) {
     if (!fmt_ctx_) return;
-    AVCodec *dec;
+    const AVCodec *dec;
     int st_nb = av_find_best_stream(fmt_ctx_.get(), AVMEDIA_TYPE_VIDEO, stream_nb, -1, &dec, 0);
     // LOG(INFO) << "find best stream: " << st_nb;
     CHECK_GE(st_nb, 0) << "ERROR cannot find video stream with wanted index: " << stream_nb;


### PR DESCRIPTION
## Environment 
Ubuntu 23.04 lunar
gcc version 12.3.0
ffmpeg version n4.3.1

## Issue
During compiling:
```
decord/src/video/video_reader.cc:149:88: error: invalid conversion from ‘AVCodec**’ to ‘const AVCodec**’ [-fpermissive]
  149 |     int st_nb = av_find_best_stream(fmt_ctx_.get(), AVMEDIA_TYPE_VIDEO, stream_nb, -1, &dec, 0);
      |                                                                                        ^~~~
      |                                                                                        |
      |                                                                                        AVCodec**

```

## Fix
Convert `AVCodec*` to const `AVCodec*` for the dec
