### PR TITLE
Fix get_batch hang - use int64_t for NDArray PTS

### DIFF
--- a/include/decord/runtime/ndarray.h
+++ b/include/decord/runtime/ndarray.h
@@ -37,7 +37,7 @@ namespace runtime {
 class NDArray {
  public:
   // pts of the frame
-  int pts=-1;
+  int64_t pts=-1;
   // internal container type
   struct Container;
   /*! \brief default constructor */


### PR DESCRIPTION
https://github.com/dmlc/decord/issues/269
When videos have very large PTS (>INTMAX), cur_frames do not match what is actually read from video, leading to the frame queue being empty, and SkipFramesImpl goes into an infinite loop