### PR TITLE
fix(video): Prevent hang in SkipFramesImpl by adding pop retry limit

### DIFF
--- a/include/decord/runtime/ndarray.h
+++ b/include/decord/runtime/ndarray.h
@@ -37,7 +37,7 @@ namespace runtime {
 class NDArray {
  public:
   // pts of the frame
-  int pts=-1;
+  int64_t pts=-1;
   // internal container type
   struct Container;
   /*! \brief default constructor */


### PR DESCRIPTION
SkipFramesImpl could hang when `decoder_->Pop` returned `false` after receiving an empty NDArray (EAGAIN signal), as the skip counter didn't decrement. If the decoder then stalled, `frame_count_` remained zero, causing subsequent `Pop` calls to fail rapidly at the entry check, leading to hangs or malloc deadlocks. This commit adds a retry limit to the `SkipFramesImpl` loop to break this rapid failure cycle after consecutive `Pop` failures. This improves robustness when skipping frames in problematic videos after seeking.