### PR TITLE
[Lazy Imports Support] Fix implicit import in function.py

### DIFF
--- a/python/decord/_ffi/function.py
+++ b/python/decord/_ffi/function.py
@@ -301,6 +301,8 @@ def _init_api_prefix(module_name, prefix):
         setattr(target_module, ff.__name__, ff)
 
 def _init_internal_api():
+    # Ensure this module has been loaded ahead of accessing it below
+    import decord._api_internal
     for name in list_global_func_names():
         if not name.startswith("_"):
             continue


### PR DESCRIPTION
This code is not fully compatible with Lazy Imports. It requires `decord._api_internal` to have been loaded ahead of the `sys.modules` access--which is not guaranteed when modules are loaded lazily. If the module was already loaded eagerly this should be essentially a no-op. 