### PR TITLE
Fix compatibility with FFmpeg 6.x

### DIFF
--- a/src/video/ffmpeg/ffmpeg_common.h
+++ b/src/video/ffmpeg/ffmpeg_common.h
@@ -21,6 +21,7 @@
 extern "C" {
 #endif
 #include <libavcodec/avcodec.h>
+#include <libavcodec/bsf.h>
 #include <libavformat/avformat.h>
 #include <libavformat/avio.h>
 #include <libavfilter/avfilter.h>

--- a/src/video/video_reader.cc
+++ b/src/video/video_reader.cc
@@ -145,7 +145,7 @@ VideoReader::~VideoReader(){
 
 void VideoReader::SetVideoStream(int stream_nb) {
     if (!fmt_ctx_) return;
-    AVCodec *dec;
+    const AVCodec *dec;
     int st_nb = av_find_best_stream(fmt_ctx_.get(), AVMEDIA_TYPE_VIDEO, stream_nb, -1, &dec, 0);
     // LOG(INFO) << "find best stream: " << st_nb;
     CHECK_GE(st_nb, 0) << "ERROR cannot find video stream with wanted index: " << stream_nb;


### PR DESCRIPTION
- Add missing #include <libavcodec/bsf.h> for AVBSFContext and av_bsf_free declarations which were moved to a separate header in newer FFmpeg versions

- Change AVCodec* to const AVCodec* in SetVideoStream() to match the updated signature of av_find_best_stream() in FFmpeg 6.x

Tested with FFmpeg 6.0 (libavcodec 60.31.102, libavformat 60.16.100)