### PR TITLE
Fix CUDA detection and modern FFmpeg compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.8.2...3.30)
+cmake_policy(SET CMP0146 NEW)
+cmake_policy(SET CMP0104 NEW)
+
 project(decord C CXX)
 
 # Utility functions

--- a/cmake/modules/CUDA.cmake
+++ b/cmake/modules/CUDA.cmake
@@ -15,37 +15,94 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# CUDA Module
-find_cuda(${USE_CUDA})
+# Modern CUDA module for Decord (CMake >= 3.10)
 
-if(CUDA_FOUND)
-  # always set the includedir when cuda is available
-  # avoid global retrigger of cmake
-  include_directories(${CUDA_INCLUDE_DIRS})
-  add_definitions(-DDECORD_USE_CUDA)
-endif(CUDA_FOUND)
-
+# =========================
+# CUDA ENABLE
+# =========================
 if(USE_CUDA)
-  if(NOT CUDA_FOUND)
-    message(FATAL_ERROR "Cannot find CUDA, USE_CUDA=" ${USE_CUDA})
-  endif()
+
+  enable_language(CUDA)
+
+  # Usa il nuovo sistema CMake
+  find_package(CUDAToolkit REQUIRED)
+
+  set(CUDA_FOUND TRUE)
+
+  # Include dirs
+  set(CUDA_INCLUDE_DIRS ${CUDAToolkit_INCLUDE_DIRS})
+  include_directories(${CUDA_INCLUDE_DIRS})
+
+  # Definizione macro
+  add_definitions(-DDECORD_USE_CUDA)
+
+  # =========================
+  # LIBRERIE CUDA
+  # =========================
+
+  # Librerie moderne (target CMake)
+  set(CUDA_CUDART_LIBRARY CUDA::cudart)
+  set(CUDA_CUDA_LIBRARY CUDA::cuda_driver)
+  set(CUDA_NVRTC_LIBRARY CUDA::nvrtc)
+
+  # NVML (non sempre presente come target)
+  find_library(
+    CUDA_NVIDIA_ML_LIBRARY
+    NAMES nvidia-ml
+    PATHS
+      /usr/lib/x86_64-linux-gnu
+      /usr/local/cuda/lib64
+      /usr/local/cuda/targets/x86_64-linux/lib/stubs
+  )
+
+  # NVDEC (fondamentale per Decord)
+  find_library(
+    CUDA_NVCUVID_LIBRARY
+    NAMES nvcuvid
+    PATHS
+      /usr/lib/x86_64-linux-gnu
+      /usr/local/cuda/lib64
+      /usr/local/cuda/targets/x86_64-linux/lib
+  )
+
   if(NOT CUDA_NVCUVID_LIBRARY)
-    message(FATAL_ERROR "Cannot find libnvcuvid, you may need to manually register and download at https://developer.nvidia.com/nvidia-video-codec-sdk. Then copy libnvcuvid to cuda_toolkit_root/lib64/" )
+    message(FATAL_ERROR
+      "Cannot find libnvcuvid. Installa il Video Codec SDK oppure verifica:\n"
+      "/usr/lib/x86_64-linux-gnu/libnvcuvid.so"
+    )
   endif()
+
   message(STATUS "Build with CUDA support")
+
+  # =========================
+  # SORGENTI CUDA
+  # =========================
+
   file(GLOB RUNTIME_CUDA_SRCS src/runtime/cuda/*.cc)
   file(GLOB NVDEC_SRCS src/video/nvcodec/*.cc)
   file(GLOB NVDEC_CUDA_SRCS src/improc/*.cu)
 
-  list(APPEND DECORD_LINKER_LIBS ${CUDA_NVRTC_LIBRARY})
-  list(APPEND DECORD_RUNTIME_LINKER_LIBS ${CUDA_CUDART_LIBRARY})
-  list(APPEND DECORD_RUNTIME_LINKER_LIBS ${CUDA_CUDA_LIBRARY})
-  list(APPEND DECORD_RUNTIME_LINKER_LIBS ${CUDA_NVRTC_LIBRARY})
-  list(APPEND DECORD_RUNTIME_LINKER_LIBS ${CUDA_NVIDIA_ML_LIBRARY})
-  list(APPEND DECORD_RUNTIME_LINKER_LIBS ${CUDA_NVCUVID_LIBRARY})
+  # =========================
+  # LINKER
+  # =========================
 
-else(USE_CUDA)
+  list(APPEND DECORD_LINKER_LIBS ${CUDA_NVRTC_LIBRARY})
+
+  list(APPEND DECORD_RUNTIME_LINKER_LIBS
+    ${CUDA_CUDART_LIBRARY}
+    ${CUDA_CUDA_LIBRARY}
+    ${CUDA_NVRTC_LIBRARY}
+    ${CUDA_NVIDIA_ML_LIBRARY}
+    ${CUDA_NVCUVID_LIBRARY}
+  )
+
+else()
+
   message(STATUS "CUDA disabled, no nvdec capabilities will be enabled...")
+
+  set(CUDA_FOUND FALSE)
   set(NVDEC_SRCS "")
   set(RUNTIME_CUDA_SRCS "")
-endif(USE_CUDA)
+  set(NVDEC_CUDA_SRCS "")
+
+endif()

--- a/src/audio/audio_reader.cc
+++ b/src/audio/audio_reader.cc
@@ -128,7 +128,7 @@ namespace decord {
                 pCodecParameters = tempCodecParameters;
                 originalSampleRate = tempCodecParameters->sample_rate;
                 if (targetSampleRate == -1) targetSampleRate = originalSampleRate;
-                numChannels = tempCodecParameters->channels;
+                numChannels = tempCodecParameters->ch_layout.nb_channels;
                 break;
             }
         }
@@ -229,7 +229,7 @@ namespace decord {
         // allocate resample buffer
         float** outBuffer;
         int outLinesize = 0;
-        int outNumChannels = av_get_channel_layout_nb_channels(mono ? AV_CH_LAYOUT_MONO : pFrame->channel_layout);
+        int outNumChannels = mono ? 1 : pFrame->ch_layout.nb_channels;
         numChannels = outNumChannels;
         int outNumSamples = av_rescale_rnd(pFrame->nb_samples,
                                            this->targetSampleRate, pFrame->sample_rate, AV_ROUND_UP);
@@ -277,22 +277,47 @@ namespace decord {
     void AudioReader::InitSWR(AVCodecContext *pCodecContext) {
         int ret = 0;
         // Set resample ctx
-        this->swr = swr_alloc();
         if (!this->swr) {
             LOG(FATAL) << "ERROR Failed to allocate resample context";
         }
-        if (pCodecContext->channel_layout == 0) {
-            pCodecContext->channel_layout = av_get_default_channel_layout( pCodecContext->channels );
+
+        AVChannelLayout in_ch_layout;
+        AVChannelLayout out_ch_layout;
+
+        if (pCodecContext->ch_layout.nb_channels > 0) {
+            av_channel_layout_copy(&in_ch_layout, &pCodecContext->ch_layout);
+        } else {
+            av_channel_layout_default(&in_ch_layout, pCodecContext->ch_layout.nb_channels);
         }
-        av_opt_set_channel_layout(this->swr, "in_channel_layout",  pCodecContext->channel_layout, 0);
-        av_opt_set_channel_layout(this->swr, "out_channel_layout", mono ? AV_CH_LAYOUT_MONO : pCodecContext->channel_layout,  0);
-        av_opt_set_int(this->swr, "in_sample_rate",     pCodecContext->sample_rate,                0);
-        av_opt_set_int(this->swr, "out_sample_rate",    this->targetSampleRate,                0);
-        av_opt_set_sample_fmt(this->swr, "in_sample_fmt",  pCodecContext->sample_fmt, 0);
-        av_opt_set_sample_fmt(this->swr, "out_sample_fmt", AV_SAMPLE_FMT_FLTP,  0);
+
+        if (mono) {
+            av_channel_layout_default(&out_ch_layout, 1);
+        } else {
+            av_channel_layout_copy(&out_ch_layout, &in_ch_layout);
+        }
+
+        ret = swr_alloc_set_opts2(
+            &this->swr,
+            &out_ch_layout,
+            AV_SAMPLE_FMT_FLTP,
+            this->targetSampleRate,
+            &in_ch_layout,
+            pCodecContext->sample_fmt,
+            pCodecContext->sample_rate,
+            0,
+            nullptr);
+
+        av_channel_layout_uninit(&in_ch_layout);
+        av_channel_layout_uninit(&out_ch_layout);
+
+        if (ret < 0 || !this->swr) {
+            LOG(FATAL) << "ERROR Failed to allocate resample context";
+        }
+
         if ((ret = swr_init(this->swr)) < 0) {
             LOG(FATAL) << "ERROR Failed to initialize resample context";
         }
+
     }
 
     void AudioReader::ToNDArray() {

--- a/src/video/ffmpeg/ffmpeg_common.h
+++ b/src/video/ffmpeg/ffmpeg_common.h
@@ -21,6 +21,7 @@
 extern "C" {
 #endif
 #include <libavcodec/avcodec.h>
+#include <libavcodec/bsf.h>
 #include <libavformat/avformat.h>
 #include <libavformat/avio.h>
 #include <libavfilter/avfilter.h>

--- a/src/video/ffmpeg/threaded_decoder.cc
+++ b/src/video/ffmpeg/threaded_decoder.cc
@@ -173,7 +173,7 @@ void FFMPEGThreadedDecoder::ProcessFrame(AVFramePtr frame, NDArray out_buf) {
 void FFMPEGThreadedDecoder::WorkerThread() {
     try {
         WorkerThreadImpl();
-    } catch (dmlc::Error error) {
+    } catch (const dmlc::Error& error) {
         RecordInternalError(error.what());
         run_.store(false);
         frame_queue_->SignalForKill(); // Unblock all consumers

--- a/src/video/nvcodec/cuda_decoder_impl.cc
+++ b/src/video/nvcodec/cuda_decoder_impl.cc
@@ -37,12 +37,20 @@ const char * GetVideoCodecString(cudaVideoCodec eCodec) {
     };
 
     if (eCodec >= 0 && eCodec <= cudaVideoCodec_NumCodecs) {
-        return aCodecName[eCodec].name;
+        if (static_cast<int>(eCodec) >= 0 &&
+            static_cast<size_t>(eCodec) < sizeof(aCodecName) / sizeof(aCodecName[0])) {
+            return aCodecName[eCodec].name;
+        }
+        return "Unknown";
     }
     for (size_t i = cudaVideoCodec_NumCodecs + 1; i < sizeof(aCodecName) / sizeof(aCodecName[0]); i++) {
         if (eCodec == aCodecName[i].eCodec) {
-            return aCodecName[eCodec].name;
-        }
+            if (static_cast<int>(eCodec) >= 0 &&
+                static_cast<size_t>(eCodec) < sizeof(aCodecName) / sizeof(aCodecName[0])) {
+                return aCodecName[eCodec].name;
+            }
+            return "Unknown";
+            }
     }
     return "Unknown";
 }

--- a/src/video/nvcodec/cuda_threaded_decoder.cc
+++ b/src/video/nvcodec/cuda_threaded_decoder.cc
@@ -17,7 +17,7 @@ namespace decord {
 namespace cuda {
 using namespace runtime;
 
-CUThreadedDecoder::CUThreadedDecoder(int device_id, AVCodecParameters *codecpar, AVInputFormat *iformat)
+CUThreadedDecoder::CUThreadedDecoder(int device_id, AVCodecParameters *codecpar, const AVInputFormat *iformat)
     : device_id_(device_id), stream_({device_id, false}), device_{}, ctx_{}, parser_{}, decoder_{},
     pkt_queue_{}, frame_queue_{},
     run_(false), frame_count_(0), draining_(false),
@@ -70,7 +70,7 @@ CUThreadedDecoder::CUThreadedDecoder(int device_id, AVCodecParameters *codecpar,
     }
 }
 
-void CUThreadedDecoder::InitBitStreamFilter(AVCodecParameters *codecpar, AVInputFormat *iformat) {
+void CUThreadedDecoder::InitBitStreamFilter(AVCodecParameters *codecpar, const AVInputFormat *iformat) {
     const char* bsf_name = nullptr;
     if (AV_CODEC_ID_H264 == codecpar->codec_id) {
         // H.264
@@ -301,7 +301,7 @@ bool CUThreadedDecoder::Pop(NDArray *frame) {
 void CUThreadedDecoder::LaunchThread() {
   try {
       LaunchThreadImpl();
-  } catch (dmlc::Error error) {
+  } catch (const dmlc::Error& error) {
       RecordInternalError(error.what());
       run_.store(false);
       frame_queue_->SignalForKill(); // Unblock all consumers

--- a/src/video/nvcodec/cuda_threaded_decoder.h
+++ b/src/video/nvcodec/cuda_threaded_decoder.h
@@ -46,7 +46,7 @@ class CUThreadedDecoder final : public ThreadedDecoderInterface {
     using FrameOrderQueuePtr = std::unique_ptr<FrameOrderQueue>;
 
     public:
-        CUThreadedDecoder(int device_id, AVCodecParameters *codecpar, AVInputFormat *iformat);
+        CUThreadedDecoder(int device_id, AVCodecParameters *codecpar, const AVInputFormat *iformat);
         void SetCodecContext(AVCodecContext *dec_ctx, int width = -1, int height = -1, int rotation = 0);
         bool Initialized() const;
         void Start();
@@ -70,7 +70,7 @@ class CUThreadedDecoder final : public ThreadedDecoderInterface {
         void LaunchThreadImpl();
         void RecordInternalError(std::string message);
         void CheckErrorStatus();
-        void InitBitStreamFilter(AVCodecParameters *codecpar, AVInputFormat *iformat);
+        void InitBitStreamFilter(AVCodecParameters *codecpar, const AVInputFormat *iformat);
 
         int device_id_;
         CUStream stream_;

--- a/src/video/video_reader.cc
+++ b/src/video/video_reader.cc
@@ -145,7 +145,7 @@ VideoReader::~VideoReader(){
 
 void VideoReader::SetVideoStream(int stream_nb) {
     if (!fmt_ctx_) return;
-    AVCodec *dec;
+    const AVCodec *dec = nullptr;
     int st_nb = av_find_best_stream(fmt_ctx_.get(), AVMEDIA_TYPE_VIDEO, stream_nb, -1, &dec, 0);
     // LOG(INFO) << "find best stream: " << st_nb;
     CHECK_GE(st_nb, 0) << "ERROR cannot find video stream with wanted index: " << stream_nb;
@@ -547,19 +547,40 @@ double VideoReader::GetRotation() const {
     if (!fmt_ctx_) return 0.0;
     CHECK(actv_stm_idx_ >= 0);
     CHECK(static_cast<unsigned int>(actv_stm_idx_) < fmt_ctx_->nb_streams);
+
     AVStream *active_st = fmt_ctx_->streams[actv_stm_idx_];
     AVDictionaryEntry *rotate = av_dict_get(active_st->metadata, "rotate", NULL, 0);
 
     double theta = 0;
-    if (rotate && *rotate->value && strcmp(rotate->value, "0"))
-        theta = atof(rotate->value);
 
-    uint8_t* displaymatrix = av_stream_get_side_data(active_st, AV_PKT_DATA_DISPLAYMATRIX, NULL);
-    if (displaymatrix && !theta)
-        theta = -av_display_rotation_get((int32_t*) displaymatrix);
+    if (rotate && *rotate->value && strcmp(rotate->value, "0")) {
+        theta = atof(rotate->value);
+    }
+
+#if LIBAVFORMAT_VERSION_MAJOR >= 60
+    // NUOVA API FFmpeg (no deprecated)
+    const AVPacketSideData* sd = av_packet_side_data_get(
+        active_st->codecpar->coded_side_data,
+        active_st->codecpar->nb_coded_side_data,
+        AV_PKT_DATA_DISPLAYMATRIX);
+
+    if (sd && sd->data && sd->size >= 9 * sizeof(int32_t) && !theta) {
+        theta = -av_display_rotation_get(reinterpret_cast<int32_t*>(sd->data));
+    }
+
+#else
+    // Vecchia API (fallback)
+    size_t displaymatrix_size = 0;
+    uint8_t* displaymatrix = av_stream_get_side_data(
+        active_st, AV_PKT_DATA_DISPLAYMATRIX, &displaymatrix_size);
+
+    if (displaymatrix && displaymatrix_size >= 9 * sizeof(int32_t) && !theta) {
+        theta = -av_display_rotation_get(reinterpret_cast<int32_t*>(displaymatrix));
+    }
+#endif
 
     theta = std::fmod(theta, 360);
-    if(theta < 0) theta += 360;
+    if (theta < 0) theta += 360;
 
     return theta;
 }


### PR DESCRIPTION
This PR updates Decord to build on newer Linux/CUDA/FFmpeg environments.

Changes:
- Replace legacy CUDA detection with CMake CUDAToolkit
- Fix CUDA detection with CUDA 12/13
- Add modern FFmpeg bitstream filter header usage
- Fix FFmpeg const-correctness issues with AVCodec and AVInputFormat
- Replace deprecated FFmpeg rotation side-data access for newer libavformat
- Fix C++ warnings such as catching dmlc::Error by value
- Add bounds check for CUDA codec string lookup

Tested on:
- Ubuntu Linux
- GCC 13
- CUDA 13.2
- CMake + Ninja
- FFmpeg / LibAV: libavcodec 60, libavformat 60, libavutil 58
- Python 3.12
- USE_CUDA=ON
- CMAKE_CUDA_ARCHITECTURES=120

Also verified local wheel build and import successfully.